### PR TITLE
Added regex_findall to blitz doc, fixed typos

### DIFF
--- a/docs/blitz/design/save/filters.rst
+++ b/docs/blitz/design/save/filters.rst
@@ -80,6 +80,28 @@ Below you can see an example of regex filter.
         bootflash:
           value: "The bootflash is %VARIABLES{bootflash} and %VARIABLES{measure}"
 
+Save with Regex findall
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Below you can see an example of regex_findall.
+In this example, execute_output would contain a list of strings such as: 
+['172.16.1.250', '10.12.90.1', '10.12.110.1', '10.12.115.1', '10.12.120.1']
+
+.. code-block:: YAML
+
+    # first saving list of values from execute action output
+    # later on printing this list
+
+    - execute:
+        device: PE1
+        command: show ip interface brief
+        save:
+        - variable_name: execute_output
+          regex_findall: (\d+\.\d+\.\d+\.\d+)                            # returns a list of IP addresses
+    - print:
+        item:
+          value: "%VARIABLES{execute_output}"
+
 Save with List filter
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/blitz/design/save/filters.rst
+++ b/docs/blitz/design/save/filters.rst
@@ -80,27 +80,23 @@ Below you can see an example of regex filter.
         bootflash:
           value: "The bootflash is %VARIABLES{bootflash} and %VARIABLES{measure}"
 
-Save with Regex findall
+Save with Regex findall filter
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Below you can see an example of regex_findall.
 In this example, execute_output would contain a list of strings such as: 
-['172.16.1.250', '10.12.90.1', '10.12.110.1', '10.12.115.1', '10.12.120.1']
+['172.16.1.254', '10.1.1.1', '10.2.2.2', '10.3.3.3', '10.4.4.4']
 
 .. code-block:: YAML
 
-    # first saving list of values from execute action output
-    # later on printing this list
+    # saves a list of values from execute action output
 
     - execute:
         device: PE1
         command: show ip interface brief
         save:
         - variable_name: execute_output
-          regex_findall: (\d+\.\d+\.\d+\.\d+)                            # returns a list of IP addresses
-    - print:
-        item:
-          value: "%VARIABLES{execute_output}"
+          regex_findall: (\d+\.\d+\.\d+\.\d+)   # returns a list of IP addresses
 
 Save with List filter
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/blitz/design/save/index.rst
+++ b/docs/blitz/design/save/index.rst
@@ -25,9 +25,11 @@ There are different ways to save values to a variable and also different ways to
 
 * :ref:`Dq filter<filters>`: This filter is named after our JSON querying tool `Dq <https://pubhub.devnetcloud.com/media/genie-docs/docs/userguide/utils/index.html#dq>`_. It will apply a query on JSON output and saves a part of a dictionary into a variable.
 
-* :ref:`Regex filter<filters>`: For actions that has string outputs you can apply a regex filter. If regex matches the output, the grouped value, that has a variable name specified like ``(?P<variable_name>)``, will be stored into that variable_name. Below you can find related examples.
+* :ref:`Regex filter<filters>`: For actions that have string outputs you can apply a regex filter. If regex matches the output, the grouped value, that has a variable name specified like ``(?P<variable_name>)``, will be stored into that variable_name. Below you can find related examples.
 
-* :ref:`List filter<filters>`: It is a specific filter that only can be applied on action outputs that are a list.
+* :ref:`Regex findall<filters>`: For actions that have string outputs you can apply a regex findall. It returns a list of all matches in the output, or an empty list if no match is found. The list will be stored into a variable_name previously declared using `variable_name` argument.
+
+* :ref:`List filter<filters>`: It is a specific filter that can only be applied to action outputs that are lists.
 
 
 Examples of saving variables with or without applying a filter on the action output can be found :ref:`here<filters>`

--- a/docs/blitz/design/save/index.rst
+++ b/docs/blitz/design/save/index.rst
@@ -27,7 +27,7 @@ There are different ways to save values to a variable and also different ways to
 
 * :ref:`Regex filter<filters>`: For actions that have string outputs you can apply a regex filter. If regex matches the output, the grouped value, that has a variable name specified like ``(?P<variable_name>)``, will be stored into that variable_name. Below you can find related examples.
 
-* :ref:`Regex findall<filters>`: For actions that have string outputs you can apply a regex findall. It returns a list of all matches in the output, or an empty list if no match is found. The list will be stored into a variable_name previously declared using `variable_name` argument.
+* :ref:`Regex findall<filters>`: For actions that have string outputs you can apply a regex findall filter. It returns a list of all matches in the output, or an empty list if no match is found. The list will be stored into a variable_name previously declared using `variable_name` argument.
 
 * :ref:`List filter<filters>`: It is a specific filter that can only be applied to action outputs that are lists.
 


### PR DESCRIPTION
Added documentation to new Blitz enhancement supporting regex_findall while saving an output to a variable
Related to the following PR (in the internal repository): 
https://wwwin-github.cisco.com/pyATS/genielibs/pull/592