### PR TITLE
[Blitz] Updated Blitz docs on save action outputs

### DIFF
--- a/docs/blitz/design/save/filters.rst
+++ b/docs/blitz/design/save/filters.rst
@@ -5,7 +5,7 @@
 Save with No filter
 ^^^^^^^^^^^^^^^^^^^^
 
-Below you can find examples of how to save the entire output to a variable name.
+Below you can find examples of how to save the entire output to a variable name and/or a file.
 
 .. code-block:: YAML
 
@@ -28,6 +28,20 @@ Below you can find examples of how to save the entire output to a variable name.
         command: show platform
         save:
           - variable_name: execute_output
+
+In the example below, the same action output is saved to a file. 
+All you need to do is provide the file name using the argument `file_name`.
+
+.. code-block:: YAML
+
+    # Description: Saving the entire output of an execute action into a file
+    # The type of output is dictionary/JSON data.
+
+    - parse:
+        device:  '%{testbed.devices.uut.alias}'
+        command: show platform
+        save:
+          - file_name: testfile.txt
 
 Save with Dq filter
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/blitz/design/save/filters.rst
+++ b/docs/blitz/design/save/filters.rst
@@ -20,7 +20,7 @@ Below you can find examples of how to save the entire output to a variable name 
 
 .. code-block:: YAML
 
-    # Description: Saving the entire output of an execute action into a variable
+    # Description: Saving the entire output of a parse action into a variable
     # The type of output is dictionary/JSON data.
 
     - parse:

--- a/docs/blitz/design/save/index.rst
+++ b/docs/blitz/design/save/index.rst
@@ -14,7 +14,7 @@ Save action outputs
 
 
 Another very useful feature that Blitz has, is the ability to save the output of actions or a variation of it.
-You can either save values to a variable name and later use that variable in other actions or export to a file that will be saved in the directory where the script was executed. 
+You can either save values to a variable name and later use that variable in other actions or save it to a file in the directory where the script was executed.
 There are different ways to save the output and also different ways to reuse them:
 
 * Save the entire output of an action.

--- a/docs/blitz/design/save/index.rst
+++ b/docs/blitz/design/save/index.rst
@@ -2,7 +2,7 @@
 
 
 
-Save variables
+Save action outputs
 ===============
 
 
@@ -13,33 +13,33 @@ Save variables
     filters
 
 
-Another very useful feature that Blitz has, is the ability to save actions output or a variation of the output.
-You can save values to a variable name and later use that variable in other actions. 
-There are different ways to save values to a variable and also different ways to reuse them:
+Another very useful feature that Blitz has, is the ability to save the output of actions or a variation of it.
+You can either save values to a variable name and later use that variable in other actions or export to a file that will be saved in the directory where the script was executed. 
+There are different ways to save the output and also different ways to reuse them:
 
-* Save the entire output of an action to a variable name.
-* Save a part of the output of an action to a variable name.
+* Save the entire output of an action.
+* Save a part of the output of an action.
 
 
 *Blitz* provides 3 forms of filters that can be applied to an action output and extract a part of the output to be saved
 
-* :ref:`Dq filter<filters>`: This filter is named after our JSON querying tool `Dq <https://pubhub.devnetcloud.com/media/genie-docs/docs/userguide/utils/index.html#dq>`_. It will apply a query on JSON output and saves a part of a dictionary into a variable.
+* :ref:`Dq filter<filters>`: This filter is named after our JSON querying tool `Dq <https://pubhub.devnetcloud.com/media/genie-docs/docs/userguide/utils/index.html#dq>`_. It will apply a query on JSON output and save it as a part of a dictionary.
 
-* :ref:`Regex filter<filters>`: For actions that have string outputs you can apply a regex filter. If regex matches the output, the grouped value, that has a variable name specified like ``(?P<variable_name>)``, will be stored into that variable_name. Below you can find related examples.
+* :ref:`Regex filter<filters>`: For actions that have string outputs you can apply a regex filter. If regex matches the output, the grouped value, that has a variable name specified like ``(?P<variable_name>)``, will be stored.
 
-* :ref:`Regex findall<filters>`: For actions that have string outputs you can apply a regex findall filter. It returns a list of all matches in the output, or an empty list if no match is found. The list will be stored into a variable_name previously declared using `variable_name` argument.
+* :ref:`Regex findall<filters>`: For actions that have string outputs you can apply a regex findall filter. It returns a list of all matches in the output, or an empty list if no match is found.
 
 * :ref:`List filter<filters>`: It is a specific filter that can only be applied to action outputs that are lists.
 
 
-Examples of saving variables with or without applying a filter on the action output can be found :ref:`here<filters>`
+Examples of saving outputs with or without applying a filter on the action output can be found :ref:`here<filters>`
 
 
 Re-use variables
 ===================
 
 The following `example` is showing how to use our specific markup language
-to load the saved variable in another action. In this example we save the output
+to load a saved variable in another action. In this example we save the output
 of the *get_interface_mtu_size* api and later use it within the command
 of the action ``configure``.
 
@@ -58,7 +58,7 @@ of the action ``configure``.
               command: |
                 router bgp '%VARIABLES{api_output}'
 
-Another example of how to use our markup language is provided below. In this example the output of the ``learn``
+Another example of how to use our markup language is provided below. In this example, the output of the ``learn``
 action is saved on variable  *main_learn_output*. Also, a filter is applied on this output and is saved
 in variable  *filtered_learn_output*. We later check the inclusion of the *filtered_learn_output*
 in action ``execute`` output and print the *main_learn_output* into the console.
@@ -135,3 +135,53 @@ by using ``"%VARIABLES{testscript.part}"``.
                   - variable_name: item
 
 
+Save action outputs to files
+===================================
+
+Action results can be saved in both variables and files and all filters applicable to variables can also be applied when saving to files.
+To save the result of an action to a file, you need to use the `file_name` argument. An example can be seen below:
+
+.. note::
+
+    A file with the name informed in file_name will be created in the runinfo directory.
+
+.. code-block:: YAML
+
+  testsave:
+      source:
+          pkg: genie.libs.sdk
+          class: triggers.blitz.blitz.Blitz
+      test_sections:
+          - apply_configuration:
+                - parse:
+                      command: show version
+                      device: R1_xe
+                      save:
+                          - file_name: file.txt
+                            filter: get_values("rtr_type")
+
+
+Moreover, it is possible to save multiple results in the same file. For this to happen, you 
+must also use `append: True`. The output (or the result of a filter) will be appended to an existing file or create it if it does not yet exist.
+
+In the example below, you can see how this can be achieved. 
+The parsed output of `show version` is saved to a variable named `parse_output` and also saved to a file named `file.txt`.
+After that, the parsed output is filtered using `get_values("rtr_type")` and the result of this operation is appended to the same file.
+
+.. code-block:: YAML
+
+  testsave:
+      source:
+          pkg: genie.libs.sdk
+          class: triggers.blitz.blitz.Blitz
+      test_sections:
+          - apply_configuration:
+                - parse:
+                      command: show version
+                      device: R1_xe
+                      save:
+                          - variable_name: parse_output
+                            file_name: file.txt
+                          - file_name: file.txt
+                            filter: get_values("rtr_type")
+                            append: True


### PR DESCRIPTION
Updated the Blitz documentation related to `save`, since it can now save action outputs to files as well as variables.