### PR TITLE
Moved 'yang" details file and yang format options explained in more detail

### DIFF
--- a/docs/blitz/design/actions/actions.rst
+++ b/docs/blitz/design/actions/actions.rst
@@ -7,3 +7,4 @@ List of blitz actions
     :maxdepth: 4
 
     actions_list
+    yang

--- a/docs/blitz/design/actions/actions_list.rst
+++ b/docs/blitz/design/actions/actions_list.rst
@@ -308,35 +308,6 @@ print
           value: "%VARIABLES{parse_output1}"
         ...
 
-yang
-^^^^^
-
-The :ref:`yang action<yang action>` is designed to work with different messaging protocols
-which include NETCONF, RESTCONF and gNMI.  Changing the connection and protocol determines
-the message format.  See :ref:`yang action details<yang action>` for other configurations.
-
-Example of configuration using NETCONF (with automated verification of edit-config on device)
-
-.. code-block:: YAML
-
-    - yang:
-        device: uut2
-        connection: netconf
-        protocol: netconf
-        operation: edit-config
-        datastore:
-          type: candidate  # empty string means type is chosen from device capabilities.
-          lock: true
-          retry: 40
-        banner: YANG EDIT-CONFIG MESSAGE
-        content:
-          namespace:
-            ios-l2vpn: http://cisco.com/ns/yang/Cisco-IOS-XE-l2vpn
-          nodes:
-          - value: 10.10.10.2
-            xpath: /native/l2vpn-config/ios-l2vpn:l2vpn/ios-l2vpn:router-id
-            edit-op: merge
-
 bash_console
 ^^^^^^^^^^^^^
 

--- a/docs/blitz/design/actions/yang.rst
+++ b/docs/blitz/design/actions/yang.rst
@@ -136,7 +136,7 @@ or a device runtime change depending on which resource you are monitoring.
 encoding
 ~~~~~~~~
 
-gNMI messaging can be asked for in different structured datatypes.
+gNMI messaging can request different structured datatypes.
 
 - JSON - defined in `RFC 7159`_
 - JSON_IETF - defined in `RFC 8259`_

--- a/docs/blitz/design/actions/yang.rst
+++ b/docs/blitz/design/actions/yang.rst
@@ -566,7 +566,69 @@ Examples
             xpath: /native/l2vpn-config/l2vpn/router-id
             
 
-- gNMI ON_CHANGE subscribe testing a config change
+- gNMI STREAM subscribe testing IPv4 statistic values >= n.
+
+.. code-block:: YAML
+
+    - yang:
+        banner: YANG SUBSCRIBE STREAM SAMPLING
+        connection: gnmi
+        operation: subscribe
+        protocol: gnmi
+        datastore:
+          lock: true
+          retry: 40
+          type: ''
+        device: uut
+        format:
+          encoding: JSON
+          request_mode: STREAM
+          sample_interval: 5
+          stream_max: 20
+          auto_validate: false
+          negative_test: false
+          pause: 0
+          timeout: 30
+        log:
+          category: test
+          module: Cisco-NX-OS-device
+          name: nx-ipv4-stats
+          revision: '2021-12-14'
+        content:
+          namespace:
+            top: http://cisco.com/ns/yang/cisco-nx-os-device
+          nodes:
+          - datatype: ''
+            default: ''
+            edit-op: ''
+            nodetype: container
+            value: ''
+            xpath: /top:System/top:ipv4-items/top:inst-items/top:iptrafficstat-items
+        returns:
+        - id: '1'
+          name: consumed
+          op: '>='
+          selected: true
+          value: '17852'
+          xpath: /System/ipv4-items/inst-items/iptrafficstat-items/consumed
+        - id: '22'
+          name: received
+          op: '>='
+          selected: true
+          value: '452581'
+          xpath: /System/ipv4-items/inst-items/iptrafficstat-items/received
+        - id: '23'
+          name: sent
+          op: '>='
+          selected: true
+          value: '13102'
+          xpath: /System/ipv4-items/inst-items/iptrafficstat-items/sent
+
+
+- gNMI ON_CHANGE subscribe testing config changes to a boolean.
+**NOTE:**
+For ON_CHANGE the returns must contain the base value of the resource as well
+as any changes to the resource setup in the test.
 
 .. code-block:: YAML
 
@@ -610,8 +672,22 @@ Examples
           name: heavyTemplate
           op: ==
           selected: true
-          value: 'false'
+          value: true                                         # the base value
           xpath: /System/igmp-items/inst-items/heavyTemplate
+        - id: '1'
+          name: heavyTemplate
+          op: ==
+          selected: false                                     # the change value
+          value: true
+          xpath: /System/igmp-items/inst-items/heavyTemplate
+    - configure:
+        banner: CONFIG CHANGE FOR ON_CHANGE
+        device: uut
+        command: no ip igmp heavy-template
+    - configure:
+        banner: CONFIG CHANGE FOR ON_CHANGE
+        device: uut
+        command: ip igmp heavy-template
     - configure:
         banner: CONFIG CHANGE FOR ON_CHANGE
         device: uut


### PR DESCRIPTION
"yang" action was split into blitz/actions_list.rst which contained a link to details/yang.rst.  Removed the summary explanation from actions_list.rst, moved yang.rst into blitz/ and added directive to it in actions.rst.  The actions list looks the same except now the "yang" action is at the end of the list and contains all the details.  Expanded the yang format section giving a detailed explanation for each parameter.
![Screen Shot 2022-11-02 at 3 24 12 PM](https://user-images.githubusercontent.com/2295386/199614054-966250a7-20cc-41b0-bc25-4b1a52366d57.png)