### PR TITLE
ON_CHANGE subscribe example second return wrong

### DIFF
--- a/docs/blitz/design/actions/yang.rst
+++ b/docs/blitz/design/actions/yang.rst
@@ -677,8 +677,8 @@ as any changes to the resource setup in the test.
         - id: '1'
           name: heavyTemplate
           op: ==
-          selected: false                                     # the change value
-          value: true
+          selected: true
+          value: false                                        # the change value
           xpath: /System/igmp-items/inst-items/heavyTemplate
     - configure:
         banner: CONFIG CHANGE FOR ON_CHANGE


### PR DESCRIPTION
Made a mistake by setting "``selected: false                 # the change value``" instead of "``value: false                 # the change value``".  This caused confusion for user trying to setup an ON_CHANGE test.